### PR TITLE
Bump org.glassfish.web:jakarta.servlet.jsp.jstl from 2.0.0 to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,22 @@
 		<dependency>
 			<groupId>org.glassfish.web</groupId>
 			<artifactId>jakarta.servlet.jsp.jstl</artifactId>
-			<version>2.0.0</version>
+			<version>3.0.1</version>
 		</dependency>
 
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.servlet.jsp</groupId>
+			<artifactId>jakarta.servlet.jsp-api</artifactId>
+			<version>3.1.1</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.tomcat.maven</groupId>


### PR DESCRIPTION
Bump org.glassfish.web:jakarta.servlet.jsp.jstl from 2.0.0 to 3.0.1 and import necessary dependencies. 